### PR TITLE
doc: ブランチ運用ルールの参照先を記述

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@
 - `Docker`
 - `Android`
 - `Kotlin`
+
+## ブランチ運用
+
+[ブランチ運用ルール](https://github.com/RyuseiNomi/makasete-choice/wiki/%E3%83%96%E3%83%A9%E3%83%B3%E3%83%81%E9%81%8B%E7%94%A8%E3%83%AB%E3%83%BC%E3%83%AB)を参照。


### PR DESCRIPTION
ブランチ運用ルールのリンクをreadmeに貼りました。